### PR TITLE
Update dependency chokidar to fix #6

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "body-parser": "^1.9.2",
-    "chokidar": "^0.11.1",
+    "chokidar": "^0.12.1",
     "express": "^4.10.2",
     "marked": "^0.3.2",
     "minimist": "^1.1.0",


### PR DESCRIPTION
There was an issue with the `chokidar` dependency. 
The `change` event for the file was never triggered.
It is fixed with version `0.12.1`.
