### PR TITLE
Add autoclosing feature for browser tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@
     socket.on('title', function(data){
       $('title').html(data)
     })
+    socket.on('kill', function(){
+      window.open('', '_self', '');
+      window.close();
+    })
   </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -87,6 +87,7 @@ Server.prototype.start = function(filePath, next){
   })
 
   app.delete('/', function(req, res){
+    io.emit('kill');
     res.end()
     process.exit()
   })


### PR DESCRIPTION
![pr](https://cloud.githubusercontent.com/assets/2142829/5423690/9698497c-82ca-11e4-9b1a-39a24285c099.gif)
Close the tab on `kill`.
`kill` is triggered when the livedown server shuts down.
