### PR TITLE
Fix socket.io version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "marked": "^0.3.2",
     "minimist": "^1.1.0",
     "request": "^2.48.0",
-    "socket.io": "^1.2.0"
+    "socket.io": "1.3.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
livedown doesn't work with socket.io higher than `1.3.0`