### PR TITLE
Fix warnings on Node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
     "url": "https://github.com/shime/livedown.git"
   },
   "keywords": [
-    "markdown", "preview", "live", "realtime"
+    "markdown",
+    "preview",
+    "live",
+    "realtime"
   ],
   "bugs": {
     "url": "https://github.com/shime/livedown/issues"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "body-parser": "^1.9.2",
-    "chokidar": "^0.12.1",
+    "chokidar": "^1.5.1",
     "express": "^4.10.2",
     "marked": "^0.3.2",
     "minimist": "^1.1.0",


### PR DESCRIPTION
While running this, I was getting some warnings on the form

```
(node) v8::ObjectTemplate::Set() with non-primitive values is deprecated
(node) and will stop working in the next major release.

==== JS stack trace =========================================

Security context: 0x13ca8d8c9fa9 <JS Object>#0#
...
```

Updating Chokidar fixed this :)