### PR TITLE
--browser now accepts options to be passed to the browser executable

### DIFF
--- a/bin/livedown
+++ b/bin/livedown
@@ -4,6 +4,7 @@ var fs = require('fs')
 var minimist = require('minimist')
 var opn = require('opn')
 var path = require('path')
+var utils = require('./../utils')
 
 var argv = minimist(process.argv.slice(2), { alias: { h: 'help' } })
 var command = argv._[0]
@@ -24,7 +25,7 @@ function log (message) {
 }
 
 function open (uri) {
-  opn(uri, {app: argv.browser}).then(null, function () {
+  opn(uri, {app: utils.splitCommandLine(argv.browser)}).then(null, function () {
     console.log('cannot open browser, please visit ' + server.URI)
   })
 }

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -3,7 +3,7 @@ usage: livedown {COMMANDS} <PATH> {OPTIONS}
   Previews markdown from PATH in browser and watches for changes.
 
 COMMANDS:
-  
+
   start PATH      Starts watching a file on a given absolute PATH.
   stop            Stops the livedown process.
 
@@ -13,5 +13,5 @@ OPTIONS:
   --open          Opens the preview in the browser.
   --verbose       Provides debug messages.
   --port PORT     Specifies the port to use.
-  --browser       Specifies the browser to use.
+  --browser       Specifies the browser command line to execute.
 

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -15,3 +15,9 @@ OPTIONS:
   --port PORT     Specifies the port to use.
   --browser       Specifies the browser command line to execute.
 
+EXAMPLES:
+
+  livedown start README.md --port 4242
+  livedown start README.md --open --browser "firefox -P livedown"
+  livedown start README.md --open --browser "'google chrome' --incognito"
+  livedown stop

--- a/test/all.js
+++ b/test/all.js
@@ -10,19 +10,13 @@ var browser = new Browser()
 
 describe('utils.splitCommandLine', function () {
   it('returns an empty array when given a falsy input', function () {
-    expect(utils.splitCommandLine(undefined)).to.be.an(Array)
-    expect(utils.splitCommandLine(undefined)).to.be.empty()
-    expect(utils.splitCommandLine(null)).to.be.an(Array)
-    expect(utils.splitCommandLine(null)).to.be.empty()
+    expect(utils.splitCommandLine(undefined)).to.eql([])
+    expect(utils.splitCommandLine(null)).to.eql([])
+    expect(utils.splitCommandLine('')).to.eql([])
   })
 
-  it('splits the input string by spaces', function () {
-    expect(utils.splitCommandLine('firefox -new-window')).to.be.an(Array)
+  it('splits the input string on spaces unless they are quoted', function () {
     expect(utils.splitCommandLine('firefox -new-window')).to.eql(['firefox', '-new-window'])
-  })
-
-  it('ignores spaces in quoted parts', function () {
-    expect(utils.splitCommandLine("'google chrome' --incognito")).to.be.an(Array)
     expect(utils.splitCommandLine("'google chrome' --incognito")).to.eql(['google chrome', '--incognito'])
   })
 })

--- a/test/all.js
+++ b/test/all.js
@@ -4,8 +4,28 @@ var expect = require('expect.js')
 var Browser = require('zombie')
 var server = require('./../server')()
 var fs = require('fs')
+var utils = require('./../utils')
 
 var browser = new Browser()
+
+describe('utils.splitCommandLine', function () {
+  it('returns an empty array when given a falsy input', function () {
+    expect(utils.splitCommandLine(undefined)).to.be.an(Array)
+    expect(utils.splitCommandLine(undefined)).to.be.empty()
+    expect(utils.splitCommandLine(null)).to.be.an(Array)
+    expect(utils.splitCommandLine(null)).to.be.empty()
+  })
+
+  it('splits the input string by spaces', function () {
+    expect(utils.splitCommandLine('firefox -new-window')).to.be.an(Array)
+    expect(utils.splitCommandLine('firefox -new-window')).to.eql(['firefox', '-new-window'])
+  })
+
+  it('ignores spaces in quoted parts', function () {
+    expect(utils.splitCommandLine("'google chrome' --incognito")).to.be.an(Array)
+    expect(utils.splitCommandLine("'google chrome' --incognito")).to.eql(['google chrome', '--incognito'])
+  })
+})
 
 describe('livedown', function () {
   before(function (done) {

--- a/utils.js
+++ b/utils.js
@@ -4,9 +4,13 @@ module.exports = {
   isPathRelative: function (p) {
     return path.normalize(p) !== path.resolve(p)
   },
+  /**
+   * splits cmd on space characters unless they are quoted
+   * example: "'google chrome' --incognito" ==> ['google chrome', '--incognito']
+   */
   splitCommandLine: function (cmd) {
     if (cmd) {
-      return cmd.match(/(?:[^\s"']+|["'][^"']*["'])+/g)
+      return cmd.match(/([^\s"']+|["'][^"']*["'])+/g)
                 .map(function (s) { return s.replace(/["']/g, '') })
     }
     return []

--- a/utils.js
+++ b/utils.js
@@ -3,5 +3,12 @@ var path = require('path')
 module.exports = {
   isPathRelative: function (p) {
     return path.normalize(p) !== path.resolve(p)
+  },
+  splitCommandLine: function (cmd) {
+    if (cmd) {
+      return cmd.match(/(?:[^\s"']+|["'][^"']*["'])+/g)
+                .map(function (s) { return s.replace(/["']/g, '') })
+    }
+    return []
   }
 }


### PR DESCRIPTION
Adds support for passing some options to the browser executable:
livedown start README.md --open --browser "firefox -P livedown"
livedown start README.md --open --browser "'google chrome' --incognito"