### PR TITLE
Fix live-reload failure for paths that include brackets

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "body-parser": "^1.9.2",
-    "chokidar": "^1.6.1",
+    "chokidar": "^2.0.0",
     "express": "^4.10.2",
     "markdown-it": "^8.3.1",
     "markdown-it-emoji": "^1.4.0",


### PR DESCRIPTION
*Bug*. Editing markdown files on paths with brackets/parenthesis (e.g. `*Dropbox (Personal)*`) causes the live-reload feature to fail.
*Fix*. Update the `chokidar` dependency. This updates their `is-glob` dependency, which caused the issue.
*Tests*. All tests pass locally. If someone wants to add a regression test that would be 👌🏻

See [this previous discussion](https://github.com/aspnet/JavaScriptServices/issues/767) for more context.