### PR TITLE
bump chokidar ^2.0.0 -> ^3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ notifications:
   email: false
 language: node_js
 node_js:
-  - "6"
-  - "7"
   - "8"
+  - "10"
+  - "12"
+  - "13"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "body-parser": "^1.9.2",
-    "chokidar": "^2.0.0",
+    "chokidar": "^3.0.0",
     "express": "^4.10.2",
     "markdown-it": "^8.3.1",
     "markdown-it-emoji": "^1.4.0",


### PR DESCRIPTION
Transitive bump from fsevents 1.x (deprecated) to 2.x. This resolves a warning during installation:

> npm WARN deprecated fsevents@1.2.9: One of your dependencies needs to upgrade to fsevents v2: 1) Proper nodejs v10+ support 2) No more fetching binaries from AWS, smaller package size