### PR TITLE
Travis builds all supported Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ notifications:
   email: false
 language: node_js
 node_js:
-  - "6"
-  - "7"
   - "8"
+  - "10"
+  - "12"
+  - "13"


### PR DESCRIPTION
Drop 6 and 7
Add 10, 12, and 13

See https://nodejs.org/en/about/releases/ for supported versions

This was motivated by wanting to bump deprecated or insecure packages that do not support 6 or 7.