### PR TITLE
Bump mocha ^3.5.0 -> ^6.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ notifications:
   email: false
 language: node_js
 node_js:
-  - "6"
-  - "7"
   - "8"
+  - "10"
+  - "12"
+  - "13"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "expect.js": "^0.3.1",
-    "mocha": "^3.5.0",
+    "mocha": "^6.2.0",
     "np": "^2.9.0",
     "standard": "^10.0.2",
     "zombie": "^5.0.7"


### PR DESCRIPTION
* Removes json3 (deprecated in favor of native JSON object)
* Bumps growl: Fixes command injection vulnerability
* Bumps debug: Fixes regular expression denial of service vulnerability