### PR TITLE
bump zombie ^5.0.7 -> ^6.1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ notifications:
   email: false
 language: node_js
 node_js:
-  - "6"
-  - "7"
   - "8"
+  - "10"
+  - "12"
+  - "13"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "mocha": "^3.5.0",
     "np": "^2.9.0",
     "standard": "^10.0.2",
-    "zombie": "^5.0.7"
+    "zombie": "^6.1.4"
   },
   "homepage": "https://github.com/shime/livedown",
   "keywords": [


### PR DESCRIPTION
* Fix npm audit warning for lodash prototype pollution
* (Unfortunately) introduces deprecation warning for using left-pad