### PR TITLE
dont allow external access to the server

### DIFF
--- a/server.js
+++ b/server.js
@@ -42,7 +42,7 @@ function Server (opts) {
   this.sock = { emit: function () {} }
 
   this.listen = function (next) {
-    server.listen(self.port, next)
+    server.listen(self.port, 'localhost', next)
   }
 
   this.watch = function (path) {


### PR DESCRIPTION
although `localhost` is hardcoded in the URI when displaying the preview, the http server listens on all interfaces and would be externally accessible when not behind a firewall. this is a security risk. this PR changes it so that the server only listens on localhost.